### PR TITLE
DIS-3845: Add web server

### DIFF
--- a/auterion-app.yml
+++ b/auterion-app.yml
@@ -14,6 +14,12 @@ services:
     build: services/slowmode-app
     ssh: false
     http:
+      /:
+        static-root: /data/webroot
+        function:
+          type: api
+          label: Slowmode App
+      
       /api:
         proxy:
           port: 8080

--- a/services/slowmode-app/ConnectionHandler.h
+++ b/services/slowmode-app/ConnectionHandler.h
@@ -12,6 +12,11 @@
 
 #include <cmath>
 
+#include "app.h"
+#include <functional>
+
+using StateChangeFunction = std::function<void(App::app_status_code_t new_state, std::string_view description, std::string_view error)>;
+
 class ConnectionHandler {
 private:
     std::shared_ptr<mav::Message> _PM_request, _PM_request_CAM_SETTINGS;
@@ -38,11 +43,18 @@ private:
 
     std::chrono::milliseconds _heartbeat_timeout{3000};
     std::shared_ptr<mav::Connection> _connection;
+    StateChangeFunction _state_change_callback;
+    void changeState(App::app_status_code_t new_state, std::string_view description, std::string_view error) const;
 
 public:
-    ConnectionHandler(const mav::MessageSet& message_set);
+    explicit ConnectionHandler(const mav::MessageSet& message_set);
     ~ConnectionHandler();
-    void sendVelocityLimits(float horizontal_speed, float vertical_speed, float yaw_rate);
+    void connect();
+    void sendVelocityLimits(float horizontal_speed, float vertical_speed, float yaw_rate) const;
+    void registerStatusChangeCallback(StateChangeFunction const& f)
+    {
+        _state_change_callback = f;
+    };
     float getFocalLength() const
     {
         return _focal_legth;

--- a/services/slowmode-app/VelocityLimits.cpp
+++ b/services/slowmode-app/VelocityLimits.cpp
@@ -58,7 +58,7 @@ bool VelocityLimits::computeAndUpdateYawRate(float focal_length, float zoom_leve
 
 bool VelocityLimits::setHorizontalSpeed(float horizontal_speed)
 {
-    if (_horizontal_speed != horizontal_speed) {
+    if (abs(_horizontal_speed - horizontal_speed) > 1e-5) {
         _horizontal_speed = horizontal_speed;
         return true;
     }
@@ -67,7 +67,7 @@ bool VelocityLimits::setHorizontalSpeed(float horizontal_speed)
 
 bool VelocityLimits::setVerticalSpeed(float vertical_speed)
 {
-    if (_vertical_speed != vertical_speed) {
+    if (abs(_vertical_speed - vertical_speed) > 1e-5) {
         _vertical_speed = vertical_speed;
         return true;
     }
@@ -76,7 +76,7 @@ bool VelocityLimits::setVerticalSpeed(float vertical_speed)
 
 bool VelocityLimits::setYawRate(float yaw_rate)
 {
-    if (_yaw_rate != yaw_rate) {
+    if (abs(_yaw_rate - yaw_rate) > 1e-5) {
         _yaw_rate = yaw_rate;
         return true;
     }

--- a/services/slowmode-app/VelocityLimits.cpp
+++ b/services/slowmode-app/VelocityLimits.cpp
@@ -9,15 +9,13 @@ VelocityLimits::VelocityLimits(
     _standard_focal_length(standard_focal_length),
     _yaw_rate_multiplicator(yaw_rate_multiplicator)
 {
-    if (_standard_focal_length > 0) {
-        _standard_focal_length;
-    } else {
+    if (_standard_focal_length <= 0) {
         _standard_focal_length = NAN;
         SPDLOG_INFO("Invalid standard focal length");
     }
 }
 
-float VelocityLimits::_computeLinearScale(float focal_length, float zoom_level)
+float VelocityLimits::_computeLinearScale(float focal_length, float zoom_level) const
 {
     if (focal_length <= 0.f || zoom_level <= 0.f) {
         SPDLOG_INFO("Invalid focal length or zoom level");
@@ -26,7 +24,7 @@ float VelocityLimits::_computeLinearScale(float focal_length, float zoom_level)
     return _standard_focal_length / (focal_length * zoom_level);
 }
 
-float VelocityLimits::_computeQuadraticScale(float focal_length, float zoom_level)
+float VelocityLimits::_computeQuadraticScale(float focal_length, float zoom_level) const
 {
     if (focal_length <= 0.f || zoom_level <= 0.f) {
         SPDLOG_INFO("Invalid focal length or zoom level");
@@ -35,13 +33,12 @@ float VelocityLimits::_computeQuadraticScale(float focal_length, float zoom_leve
     return pow(_computeLinearScale(focal_length, zoom_level), 2);
 }
 
-void VelocityLimits::computeAndUpdateYawRate(float focal_length, float zoom_level, float standard_focal_length, int mode)
+bool VelocityLimits::computeAndUpdateYawRate(float focal_length, float zoom_level, int mode)
 {
     // If Pyaload Manager does not report focal length or zoom level, set yaw rate
     // to default
     if (focal_length != focal_length || focal_length <= 0.f || zoom_level != zoom_level || zoom_level <= 0.f) {
-        setYawRateInDegrees(_max_yaw_rate);
-        return;
+        return setYawRateInDegrees(_max_yaw_rate);
     }
 
     float yaw_rate_scale = 1.0f;
@@ -56,40 +53,52 @@ void VelocityLimits::computeAndUpdateYawRate(float focal_length, float zoom_leve
             yaw_rate_scale = _computeLinearScale(focal_length, zoom_level);
             break;
     }
-    setYawRateInDegrees(_max_yaw_rate * yaw_rate_scale * _yaw_rate_multiplicator);
+    return setYawRateInDegrees(_max_yaw_rate * yaw_rate_scale * _yaw_rate_multiplicator);
 }
 
-void VelocityLimits::setHorizontalSpeed(float horizontal_speed)
+bool VelocityLimits::setHorizontalSpeed(float horizontal_speed)
 {
-    _horizontal_speed = horizontal_speed;
+    if (_horizontal_speed != horizontal_speed) {
+        _horizontal_speed = horizontal_speed;
+        return true;
+    }
+    return false;
 }
 
-void VelocityLimits::setVerticalSpeed(float vertical_speed)
+bool VelocityLimits::setVerticalSpeed(float vertical_speed)
 {
-    _vertical_speed = vertical_speed;
+    if (_vertical_speed != vertical_speed) {
+        _vertical_speed = vertical_speed;
+        return true;
+    }
+    return false;
 }
 
-void VelocityLimits::setYawRate(float yaw_rate)
+bool VelocityLimits::setYawRate(float yaw_rate)
 {
-    _yaw_rate = yaw_rate;
+    if (_yaw_rate != yaw_rate) {
+        _yaw_rate = yaw_rate;
+        return true;
+    }
+    return false;
 }
 
-void VelocityLimits::setYawRateInDegrees(float yaw_rate)
+bool VelocityLimits::setYawRateInDegrees(float yaw_rate)
 {
-    _yaw_rate = yaw_rate * M_PI / 180;
+    return setYawRate(yaw_rate * float(M_PI) / 180);
 }
 
-float VelocityLimits::getHorizontalSpeed()
+float VelocityLimits::getHorizontalSpeed() const
 {
     return _horizontal_speed;
 }
 
-float VelocityLimits::getVerticalSpeed()
+float VelocityLimits::getVerticalSpeed() const
 {
     return _vertical_speed;
 }
 
-float VelocityLimits::getYawRate()
+float VelocityLimits::getYawRate() const
 {
     return _yaw_rate;
 }

--- a/services/slowmode-app/VelocityLimits.h
+++ b/services/slowmode-app/VelocityLimits.h
@@ -17,21 +17,21 @@ private:
     float _standard_fov;
     float _yaw_rate_multiplicator;
 
-    float _computeLinearScale(float focal_length, float zoom_level);
-    float _computeQuadraticScale(float focal_length, float zoom_level);
+    float _computeLinearScale(float focal_length, float zoom_level) const;
+    float _computeQuadraticScale(float focal_length, float zoom_level) const;
 
 public:
     VelocityLimits(float horizontal_speed, float vertical_speed, float yaw_rate, float standard_focal_length, float yaw_rate_multiplicator);
 
-    void computeAndUpdateYawRate(float focal_length, float standard_focal_length, float zoom_level, int mode = 0);
-    void setHorizontalSpeed(float horizontal_speed);
-    void setVerticalSpeed(float vertical_speed);
-    void setYawRate(float yaw_rate);
-    void setYawRateInDegrees(float yaw_rate);
+    bool computeAndUpdateYawRate(float focal_length, float zoom_level, int mode = 0);
+    bool setHorizontalSpeed(float horizontal_speed);
+    bool setVerticalSpeed(float vertical_speed);
+    bool setYawRate(float yaw_rate);
+    bool setYawRateInDegrees(float yaw_rate);
 
-    float getHorizontalSpeed();
-    float getVerticalSpeed();
-    float getYawRate();
+    float getHorizontalSpeed() const;
+    float getVerticalSpeed() const;
+    float getYawRate() const;
 };
 
 #endif // VELOCITYLIMITS_H

--- a/services/slowmode-app/app.cpp
+++ b/services/slowmode-app/app.cpp
@@ -28,7 +28,6 @@ void App::stateCallback(app_status_code_t new_state, std::string_view descriptio
     _appStatus.error = error;
 
     if (new_state == app_status_code_t::ERROR) {
-        // case app_status_code_t::ERROR:
         SPDLOG_ERROR("Slowmode App Error: {}", description);
     } else {
         SPDLOG_INFO("Slowmode App: {}", description);

--- a/services/slowmode-app/app.h
+++ b/services/slowmode-app/app.h
@@ -18,6 +18,7 @@ private:
     };
     restinio::running_server_handle_t<my_server_traits> _server;
 
+public:
     // Describe the general status of the app
     enum app_status_code_t { ERROR = -1, LOADING, SUCCESS, UNDEFINED };
 
@@ -27,10 +28,10 @@ private:
         std::string error;
     };
 
-    app_status_t _appStatus = {app_status_code_t::UNDEFINED, "Initializing", ""};
-    std::unique_ptr<restinio::router::express_router_t<>> _createRouter();
-
-public:
     void stateCallback(app_status_code_t new_state, std::string_view description, std::string_view error);
     void run();
+
+private:
+    app_status_t _appStatus = {app_status_code_t::UNDEFINED, "Initializing", ""};
+    std::unique_ptr<restinio::router::express_router_t<>> _createRouter();
 };

--- a/services/slowmode-app/app.h
+++ b/services/slowmode-app/app.h
@@ -5,7 +5,6 @@
 #include <restinio/all.hpp>
 #include <csignal>
 #include <iostream>
-// #include <magic_enum.hpp>
 
 #include <spdlog/spdlog.h>
 #include <spdlog/cfg/env.h>

--- a/services/slowmode-app/main.cpp
+++ b/services/slowmode-app/main.cpp
@@ -34,20 +34,6 @@ std::string getEnvVar(std::string const& key)
     return val;
 }
 
-void manualBroadcast(VelocityLimits& velocityLimits, const ConnectionHandler& ch, char** argv)
-{
-    SPDLOG_INFO("Manual velocity limits");
-    velocityLimits.setHorizontalSpeed(std::stof(argv[1]));
-    velocityLimits.setVerticalSpeed(std::stof(argv[2]));
-    velocityLimits.setYawRateInDegrees(std::stof(argv[3]));
-
-    while (!should_exit) {
-        ch.sendVelocityLimits(velocityLimits.getHorizontalSpeed(), velocityLimits.getVerticalSpeed(), velocityLimits.getYawRate());
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    }
-    return;
-}
-
 void constructStatusDescription(const float horizontalSpeed, const float verticalSpeed, const float yawRate, std::string& description)
 {
     if (std::isnan(horizontalSpeed) && std::isnan(verticalSpeed) && std::isnan(yawRate)) {
@@ -111,15 +97,6 @@ int main(int argc, char** argv)
 
     std::string description = "";
     std::string error = "";
-
-    // Manual assignments of velocity limits if 3 arguments are passed
-    if (argc == 4) {
-        constructStatusDescription(
-            velocityLimits.getHorizontalSpeed(), velocityLimits.getVerticalSpeed(), velocityLimits.getYawRate(), description);
-        app.stateCallback(App::app_status_code_t::SUCCESS, description, error);
-        manualBroadcast(velocityLimits, ch, argv);
-        return 0;
-    }
 
     while (!should_exit) {
         bool updated = false;

--- a/services/slowmode-app/main.cpp
+++ b/services/slowmode-app/main.cpp
@@ -53,7 +53,7 @@ void constructStatusDescription(const float horizontalSpeed, const float vertica
     if (std::isnan(horizontalSpeed) && std::isnan(verticalSpeed) && std::isnan(yawRate)) {
         description = "No velocity limits set";
     } else {
-        description = fmt::format("Current limits: ");
+        description = "Current limits: ";
         if (!std::isnan(horizontalSpeed)) {
             description += fmt::format("Horizontal speed: {:.2f}", horizontalSpeed);
         }
@@ -64,7 +64,6 @@ void constructStatusDescription(const float horizontalSpeed, const float vertica
             description += fmt::format(" Yaw rate: {:.2f}", yawRate);
         }
     }
-    return;
 }
 
 int main(int argc, char** argv)

--- a/services/slowmode-app/main.cpp
+++ b/services/slowmode-app/main.cpp
@@ -18,7 +18,7 @@ namespace fs = std::filesystem;
 
 std::atomic<bool> should_exit(false);
 
-void signal_handler(int signal)
+void signal_handler([[maybe_unused]] int signal)
 {
     should_exit = true;
 }
@@ -34,7 +34,7 @@ std::string getEnvVar(std::string const& key)
     return val;
 }
 
-void manualBroadcast(VelocityLimits& velocityLimits, ConnectionHandler& ch, char** argv)
+void manualBroadcast(VelocityLimits& velocityLimits, const ConnectionHandler& ch, char** argv)
 {
     SPDLOG_INFO("Manual velocity limits");
     velocityLimits.setHorizontalSpeed(std::stof(argv[1]));
@@ -44,6 +44,25 @@ void manualBroadcast(VelocityLimits& velocityLimits, ConnectionHandler& ch, char
     while (!should_exit) {
         ch.sendVelocityLimits(velocityLimits.getHorizontalSpeed(), velocityLimits.getVerticalSpeed(), velocityLimits.getYawRate());
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+    return;
+}
+
+void constructStatusDescription(const float horizontalSpeed, const float verticalSpeed, const float yawRate, std::string& description)
+{
+    if (std::isnan(horizontalSpeed) && std::isnan(verticalSpeed) && std::isnan(yawRate)) {
+        description = "No velocity limits set";
+    } else {
+        description = fmt::format("Current limits: ");
+        if (!std::isnan(horizontalSpeed)) {
+            description += fmt::format("Horizontal speed: {:.2f}", horizontalSpeed);
+        }
+        if (!std::isnan(verticalSpeed)) {
+            description += fmt::format(" Vertical speed: {:.2f}", verticalSpeed);
+        }
+        if (!std::isnan(yawRate)) {
+            description += fmt::format(" Yaw rate: {:.2f}", yawRate);
+        }
     }
     return;
 }
@@ -82,24 +101,38 @@ int main(int argc, char** argv)
 
     SPDLOG_INFO("Max yaw rate: {}", max_yaw_rate_with_camera);
     SPDLOG_INFO("Yaw rate multiplicator: {}", yaw_rate_multiplicator);
-
     SPDLOG_INFO("Starting connection handler...");
 
     ConnectionHandler ch(message_set);
-    // ch = std::make_unique<ConnectionHandler>(message_set);
+    ch.registerStatusChangeCallback([&app](App::app_status_code_t new_state, std::string_view description, std::string_view error) {
+        app.stateCallback(new_state, description, error);
+    });
+    ch.connect();
     VelocityLimits velocityLimits(NAN, NAN, max_yaw_rate_with_camera, standard_focal_length, yaw_rate_multiplicator);
+
+    std::string description = "";
+    std::string error = "";
 
     // Manual assignments of velocity limits if 3 arguments are passed
     if (argc == 4) {
+        constructStatusDescription(
+            velocityLimits.getHorizontalSpeed(), velocityLimits.getVerticalSpeed(), velocityLimits.getYawRate(), description);
+        app.stateCallback(App::app_status_code_t::SUCCESS, description, error);
         manualBroadcast(velocityLimits, ch, argv);
         return 0;
     }
 
     while (!should_exit) {
+        bool updated = false;
         if (ch.pmExists()) {
-            velocityLimits.computeAndUpdateYawRate(ch.getFocalLength(), ch.getZoomLevel(), standard_focal_length);
+            updated = velocityLimits.computeAndUpdateYawRate(ch.getFocalLength(), ch.getZoomLevel());
         } else {
-            velocityLimits.setYawRateInDegrees(NAN);
+            updated = velocityLimits.setYawRateInDegrees(NAN);
+        }
+        if (updated) {
+            constructStatusDescription(
+                velocityLimits.getHorizontalSpeed(), velocityLimits.getVerticalSpeed(), velocityLimits.getYawRate(), description);
+            app.stateCallback(App::app_status_code_t::SUCCESS, description, error);
         }
         ch.sendVelocityLimits(velocityLimits.getHorizontalSpeed(), velocityLimits.getVerticalSpeed(), velocityLimits.getYawRate());
 


### PR DESCRIPTION
This adds webserver to the application to handle request on `/api/status` endpoint.
The reply follows a pattern where it contains 3 fields:
* `status`: `-1` - ERROR, `0` - LOADING, `1` - SUCCESS, `2` - UNDEFINED
* `status_description`: String describing current state (optional)
* `error`: String describing error (optional)

![image](https://github.com/Auterion/slow-mode-app/assets/45992109/b8c3e3cd-db1c-4ace-833b-74027a2c6c49)
