### PR TITLE
Update libmav; correctly handle float comparison

### DIFF
--- a/services/slowmode-app/VelocityLimits.cpp
+++ b/services/slowmode-app/VelocityLimits.cpp
@@ -4,7 +4,6 @@ VelocityLimits::VelocityLimits(
     float horizontal_speed, float vertical_speed, float yaw_rate, float standard_focal_length, float yaw_rate_multiplicator) :
     _horizontal_speed(horizontal_speed),
     _vertical_speed(vertical_speed),
-    _yaw_rate(yaw_rate),
     _max_yaw_rate(yaw_rate),
     _standard_focal_length(standard_focal_length),
     _yaw_rate_multiplicator(yaw_rate_multiplicator)
@@ -13,6 +12,7 @@ VelocityLimits::VelocityLimits(
         _standard_focal_length = NAN;
         SPDLOG_INFO("Invalid standard focal length");
     }
+    _yaw_rate = NAN;
 }
 
 float VelocityLimits::_computeLinearScale(float focal_length, float zoom_level) const
@@ -37,7 +37,7 @@ bool VelocityLimits::computeAndUpdateYawRate(float focal_length, float zoom_leve
 {
     // If Pyaload Manager does not report focal length or zoom level, set yaw rate
     // to default
-    if (focal_length != focal_length || focal_length <= 0.f || zoom_level != zoom_level || zoom_level <= 0.f) {
+    if (std::isnan(focal_length) || focal_length <= 0.f || std::isnan(zoom_level) || zoom_level <= 0.f) {
         return setYawRateInDegrees(_max_yaw_rate);
     }
 
@@ -76,7 +76,9 @@ bool VelocityLimits::setVerticalSpeed(float vertical_speed)
 
 bool VelocityLimits::setYawRate(float yaw_rate)
 {
-    if (abs(_yaw_rate - yaw_rate) > 1e-5) {
+    if (std::isnan(yaw_rate) && std::isnan(_yaw_rate)) {
+        return false;
+    } else if (std::isnan(yaw_rate) != std::isnan(_yaw_rate) || fabs(_yaw_rate - yaw_rate) > 1e-5) {
         _yaw_rate = yaw_rate;
         return true;
     }
@@ -85,9 +87,6 @@ bool VelocityLimits::setYawRate(float yaw_rate)
 
 bool VelocityLimits::setYawRateInDegrees(float yaw_rate)
 {
-    if (yaw_rate != yaw_rate) {
-        return setYawRate(NAN);
-    }
     return setYawRate(yaw_rate * float(M_PI) / 180);
 }
 

--- a/services/slowmode-app/app.cpp
+++ b/services/slowmode-app/app.cpp
@@ -23,6 +23,9 @@ std::unique_ptr<restinio::router::express_router_t<>> App::_createRouter()
 void App::stateCallback(app_status_code_t new_state, std::string_view description, std::string_view error)
 {
     std::lock_guard<std::mutex> lock(_state_mtx);
+    if (new_state == _appStatus.code && description == _appStatus.description && error == _appStatus.error) {
+        return;
+    }
     _appStatus.code = new_state;
     _appStatus.description = description;
     _appStatus.error = error;

--- a/services/slowmode-app/main.cpp
+++ b/services/slowmode-app/main.cpp
@@ -47,7 +47,7 @@ void constructStatusDescription(const float horizontalSpeed, const float vertica
             description += fmt::format(" Vertical speed: {:.2f}", verticalSpeed);
         }
         if (!std::isnan(yawRate)) {
-            description += fmt::format(" Yaw rate: {:.2f}", yawRate);
+            description += fmt::format(" Yaw rate: {:.2f} rad/s", yawRate);
         }
     }
 }
@@ -98,8 +98,7 @@ int main(int argc, char** argv)
     std::string description = "";
     std::string error = "";
 
-    constructStatusDescription(
-                NAN, NAN, NAN, description);
+    constructStatusDescription(NAN, NAN, NAN, description);
     app.stateCallback(App::app_status_code_t::SUCCESS, description, error);
 
     while (!should_exit) {


### PR DESCRIPTION
Update slibmav and fixes a float comparison.
Could not reproduce reported [issue](https://auterion.atlassian.net/browse/AMC-4796?atlOrigin=eyJpIjoiOTJiZjE4N2IxYWQ3NDAyYzljNzZhZDUzOGU5YjliZTQiLCJwIjoiaiJ9). Will test it end-to-end on Monday again.