### PR TITLE
Fix increasing CPU load and dual payload setups

### DIFF
--- a/services/slowmode-app/ConnectionHandler.h
+++ b/services/slowmode-app/ConnectionHandler.h
@@ -26,7 +26,7 @@ private:
     mav::TCPClient physical = mav::TCPClient("10.41.1.1", 5790);
 #endif
 
-    std::pair<int, int> _min_max_target_search = {100, 106};
+    std::pair<int, int> _min_max_target_search = {100, 100};
     std::thread _PM_thread, _PM_heartbeat_thread;
     const mav::MessageSet& _message_set;
     std::shared_ptr<mav::NetworkRuntime> _runtime;

--- a/services/slowmode-app/Dockerfile
+++ b/services/slowmode-app/Dockerfile
@@ -22,7 +22,7 @@ RUN curl --proto "=https" -L https://github.com/Stiffstream/restinio/releases/do
 
 COPY . ./app/
 
-RUN cmake -S ./app/ -B /app/build -DBUILD_SHARED_LIBS=OFF
+RUN cmake -S ./app/ -B /app/build -DCMAKE_BUILD_TYPE=Release
 RUN cmake --build ./app/build -j 8
 
 FROM auterion/app-base:v2 as run-stage

--- a/services/slowmode-app/main.cpp
+++ b/services/slowmode-app/main.cpp
@@ -47,7 +47,7 @@ void constructStatusDescription(const float horizontalSpeed, const float vertica
             description += fmt::format(" Vertical speed: {:.2f}", verticalSpeed);
         }
         if (!std::isnan(yawRate)) {
-            description += fmt::format(" Yaw rate: {:.2f} rad/s", yawRate);
+            description += fmt::format(" Yaw rate: {:.2f} deg/s", yawRate / M_PI * 180.0f);
         }
     }
 }


### PR DESCRIPTION
- libmav has an unordered map for the expected messages. When receive was called with a timeout and the timeout was reached, then the expected message was not removed from the map. The `CAMERA_SETTINGS` message is only send when the settings change or on request, so most of the calls to receive timed out. As a result, the number of items in the map kept increasing which in turn lead to the increase in CPU load.
This PR updates the libmav submodule to a version with the fix.
https://auterion.atlassian.net/browse/MC-996?atlOrigin=eyJpIjoiNGEzOTc1YWJiOGEwNGM4MjhkYjZmNDRlMzRlMzAxNGQiLCJwIjoiaiJ9
- Astro is enabling support for an FPV camera in addition to the main payload. The current implementation in the slowmode-app uses the first camera that shows up which most often is the FPV camera. In that case, the yaw rate scaling based on the zoom doesn't work. On Astro, A7R and Wiris are assigned the component ID 100. So, for now we limit the range of valid
component IDs to just 100.
https://auterion.atlassian.net/browse/MC-998?atlOrigin=eyJpIjoiZTRjY2YyZDg1MmYwNDFiOThlZDRjMTI0YmYxMjhjMjAiLCJwIjoiaiJ9